### PR TITLE
Fix SDL2 instal command line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ A brief description on how to set-up a Raspberry Pi to use this software.
 
    ::
 
-        $ sudo apt-get libsdl2-*
+        $ sudo apt-get install libsdl2-*
 
 5. Optionally install the last stable ``gPhoto2`` version (required only for DSLR camera):
 


### PR DESCRIPTION
Replace `sudo apt-get libsdl2-*` by `sudo apt-get install libsdl2-*` to make it work!